### PR TITLE
New API

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,8 @@ eef_pose[2, 3] = 0.4
 tcp_transform = np.identity(4)
 tcp_transform[2, 3] = 0.1
 
-ur3e.forward_kinematics(0, 0, 0, 0, 0, 0)
-ur3e.forward_kinematics(*joints)
-tcp_pose = ur3e.forward_kinematics_with_tcp(*joints, tcp_transform)
+ur3e.forward_kinematics(joints)
+tcp_pose = ur3e.forward_kinematics(joints, tcp_transform)
 
 joint_solutions = ur3e.inverse_kinematics(eef_pose)
 joint_solutions = ur3e.inverse_kinematics_closest(eef_pose, *joints)
@@ -73,7 +72,7 @@ joint_solutions = ur3e.inverse_kinematics_with_tcp(eef_pose, tcp_transform)
 Development
 --------------------
 
-This codebase uses [nanobind]() to provide python bindings for the FK/IK functions.
+This codebase uses [nanobind](https://nanobind.readthedocs.io/en/latest/index.html) to provide python bindings for the FK/IK functions.
 
 ## building
 **python package building** 

--- a/src/ur_analytic_ik/forward_kinematics.hh
+++ b/src/ur_analytic_ik/forward_kinematics.hh
@@ -3,6 +3,7 @@
 #include <Eigen/Dense>
 
 using Matrix4x4 = Eigen::Matrix<double, 4, 4, Eigen::RowMajor>;
+using Vector6d = Eigen::Matrix<double, 6, 1>;
 
 Matrix4x4 dh_matrix(double theta_i, double d_i, double a_i, double alpha_i) {
   // TODO: figure out how to make this more legible
@@ -36,55 +37,60 @@ Matrix4x4 ur_forward_kinematics(double theta1,
 }
 
 namespace ur3e {
-Matrix4x4 forward_kinematics(
-    double theta1, double theta2, double theta3, double theta4, double theta5, double theta6) {
-  return ur_forward_kinematics(theta1, theta2, theta3, theta4, theta5, theta6, d1, d4, d5, d6, a2, a3);
-}
-
-Matrix4x4 forward_kinematics_with_tcp(double theta1,
-                                      double theta2,
-                                      double theta3,
-                                      double theta4,
-                                      double theta5,
-                                      double theta6,
-                                      const Matrix4x4 &tcp_transform) {
-  return forward_kinematics(theta1, theta2, theta3, theta4, theta5, theta6) * tcp_transform;
+Matrix4x4 forward_kinematics(const Vector6d &joint_angles, Matrix4x4 tcp_pose = Matrix4x4::Identity()) {
+  assert(joint_angles.size() == 6 && "Joint angles vector must contain exactly 6 elements");
+  return ur_forward_kinematics(joint_angles[0],
+                               joint_angles[1],
+                               joint_angles[2],
+                               joint_angles[3],
+                               joint_angles[4],
+                               joint_angles[5],
+                               d1,
+                               d4,
+                               d5,
+                               d6,
+                               a2,
+                               a3) *
+         tcp_pose;
 }
 
 }  // namespace ur3e
 
 namespace ur5e {
-Matrix4x4 forward_kinematics(
-    double theta1, double theta2, double theta3, double theta4, double theta5, double theta6) {
-  return ur_forward_kinematics(theta1, theta2, theta3, theta4, theta5, theta6, d1, d4, d5, d6, a2, a3);
+Matrix4x4 forward_kinematics(const Vector6d &joint_angles, Matrix4x4 tcp_pose = Matrix4x4::Identity()) {
+  assert(joint_angles.size() == 6 && "Joint angles vector must contain exactly 6 elements");
+  return ur_forward_kinematics(joint_angles[0],
+                               joint_angles[1],
+                               joint_angles[2],
+                               joint_angles[3],
+                               joint_angles[4],
+                               joint_angles[5],
+                               d1,
+                               d4,
+                               d5,
+                               d6,
+                               a2,
+                               a3) *
+         tcp_pose;
 }
-
-Matrix4x4 forward_kinematics_with_tcp(double theta1,
-                                      double theta2,
-                                      double theta3,
-                                      double theta4,
-                                      double theta5,
-                                      double theta6,
-                                      const Matrix4x4 &tcp_transform) {
-  return forward_kinematics(theta1, theta2, theta3, theta4, theta5, theta6) * tcp_transform;
-}
-
 }  // namespace ur5e
 
 namespace ur10e {
-Matrix4x4 forward_kinematics(
-    double theta1, double theta2, double theta3, double theta4, double theta5, double theta6) {
-  return ur_forward_kinematics(theta1, theta2, theta3, theta4, theta5, theta6, d1, d4, d5, d6, a2, a3);
-}
-
-Matrix4x4 forward_kinematics_with_tcp(double theta1,
-                                      double theta2,
-                                      double theta3,
-                                      double theta4,
-                                      double theta5,
-                                      double theta6,
-                                      const Matrix4x4 &tcp_transform) {
-  return forward_kinematics(theta1, theta2, theta3, theta4, theta5, theta6) * tcp_transform;
+Matrix4x4 forward_kinematics(const Vector6d &joint_angles, Matrix4x4 tcp_pose = Matrix4x4::Identity()) {
+  assert(joint_angles.size() == 6 && "Joint angles vector must contain exactly 6 elements");
+  return ur_forward_kinematics(joint_angles[0],
+                               joint_angles[1],
+                               joint_angles[2],
+                               joint_angles[3],
+                               joint_angles[4],
+                               joint_angles[5],
+                               d1,
+                               d4,
+                               d5,
+                               d6,
+                               a2,
+                               a3) *
+         tcp_pose;
 }
 
 }  // namespace ur10e

--- a/src/ur_analytic_ik/ur_analytic_ik_ext.cpp
+++ b/src/ur_analytic_ik/ur_analytic_ik_ext.cpp
@@ -10,35 +10,28 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace std;
 
-// TODO document the how/why of these define functions
 void define_forward_kinematics(nb::module_ &robot_module,
-                               std::function<Matrix4x4(double, double, double, double, double, double)> fk_function) {
+                               std::function<Matrix4x4(Vector6d,Matrix4x4)> fk_function) {
   robot_module.def("forward_kinematics",
-                   [=](double theta1, double theta2, double theta3, double theta4, double theta5, double theta6) {
+                   [=](Vector6d joint_angles, Matrix4x4 tcp_in_flange_pose = Matrix4x4::Identity()) {
                      // Call the FK function
-                     Matrix4x4 rowMajorMatrix = fk_function(theta1, theta2, theta3, theta4, theta5, theta6);
+                     Matrix4x4 rowMajorMatrix = fk_function(joint_angles, tcp_in_flange_pose);
                      return rowMajorMatrix;
-                   });
+                   }, "joint_angles"_a, "tcp_pose"_a = Matrix4x4::Identity(),
+                   "Calculates the forward kinematics of the robot, providing the TCP pose in the robot's base frame for a given joint configuration"
+                   //TODO(tlpss): figure out how to use multi-line docstrings 
+
+                  //  "Calculates the forward kinematics of the robot, providing the TCP pose in the robot's base frame for a given joint configuration
+                  //  Also takes in the offset (pose) of the TCP w.r.t. the flange frame, as the FK function only knows the kinematics of the robot, not the tool.
+
+                  //   :param joint_angles: A 6-element vector containing the joint angles in radians.
+                  //   :param tcp_pose: A 4x4 matrix representing the pose of the TCP in the robot tool frame. Defaults to identity, in which case the TCP is assumed to be at the flange.
+
+                  //   :return: A 4x4 matrix representing the pose of the TCP in the robot base frame.
+                  //  "
+                   );
 }
 
-void define_forward_kinematics_with_tcp(
-    nb::module_ &robot_module,
-    std::function<Matrix4x4(double, double, double, double, double, double, Matrix4x4)> fk_with_tcp_function) {
-  robot_module.def("forward_kinematics_with_tcp",
-                   [=](double theta1,
-                       double theta2,
-                       double theta3,
-                       double theta4,
-                       double theta5,
-                       double theta6,
-                       Matrix4x4 tcp_transform) {
-                     // Call the FK function
-                     Matrix4x4 rowMajorMatrix = fk_with_tcp_function(
-                         theta1, theta2, theta3, theta4, theta5, theta6, tcp_transform);
-
-                     return rowMajorMatrix;
-                   });
-}
 
 void define_inverse_kinematics(nb::module_ &robot_module,
                                std::function<std::vector<Matrix1x6>(Matrix4x4)> ik_function) {
@@ -96,7 +89,6 @@ void define_inverse_kinematics_closest_with_tcp(
 NB_MODULE(ur_analytic_ik_ext, m) {
   nb::module_ m_ur3e = m.def_submodule("ur3e", "UR3e module");
   define_forward_kinematics(m_ur3e, ur3e::forward_kinematics);
-  define_forward_kinematics_with_tcp(m_ur3e, ur3e::forward_kinematics_with_tcp);
   define_inverse_kinematics(m_ur3e, ur3e::inverse_kinematics);
   define_inverse_kinematics_closest(m_ur3e, ur3e::inverse_kinematics_closest);
   define_inverse_kinematics_with_tcp(m_ur3e, ur3e::inverse_kinematics_with_tcp);
@@ -104,7 +96,6 @@ NB_MODULE(ur_analytic_ik_ext, m) {
 
   nb::module_ m_ur5e = m.def_submodule("ur5e", "UR5e module");
   define_forward_kinematics(m_ur5e, ur5e::forward_kinematics);
-  define_forward_kinematics_with_tcp(m_ur5e, ur5e::forward_kinematics_with_tcp);
   define_inverse_kinematics(m_ur5e, ur5e::inverse_kinematics);
   define_inverse_kinematics_closest(m_ur5e, ur5e::inverse_kinematics_closest);
   define_inverse_kinematics_with_tcp(m_ur5e, ur5e::inverse_kinematics_with_tcp);
@@ -112,7 +103,6 @@ NB_MODULE(ur_analytic_ik_ext, m) {
 
   nb::module_ m_ur10e = m.def_submodule("ur10e", "UR10e module");
   define_forward_kinematics(m_ur10e, ur10e::forward_kinematics);
-  define_forward_kinematics_with_tcp(m_ur10e, ur10e::forward_kinematics_with_tcp);
   define_inverse_kinematics(m_ur10e, ur10e::inverse_kinematics);
   define_inverse_kinematics_closest(m_ur10e, ur10e::inverse_kinematics_closest);
   define_inverse_kinematics_with_tcp(m_ur10e, ur10e::inverse_kinematics_with_tcp);

--- a/src/ur_analytic_ik/ur_analytic_ik_ext.cpp
+++ b/src/ur_analytic_ik/ur_analytic_ik_ext.cpp
@@ -10,34 +10,31 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace std;
 
-// TODO document the how/why of these define functions
-void define_forward_kinematics(nb::module_ &robot_module,
-                               std::function<Matrix4x4(double, double, double, double, double, double)> fk_function) {
-  robot_module.def("forward_kinematics",
-                   [=](double theta1, double theta2, double theta3, double theta4, double theta5, double theta6) {
-                     // Call the FK function
-                     Matrix4x4 rowMajorMatrix = fk_function(theta1, theta2, theta3, theta4, theta5, theta6);
-                     return rowMajorMatrix;
-                   });
-}
+void define_forward_kinematics(nb::module_ &robot_module, std::function<Matrix4x4(Vector6d, Matrix4x4)> fk_function) {
+  robot_module.def(
+      "forward_kinematics",
+      [=](Vector6d joint_angles, Matrix4x4 tcp_in_flange_pose = Matrix4x4::Identity()) {
+        // Call the FK function
+        Matrix4x4 rowMajorMatrix = fk_function(joint_angles, tcp_in_flange_pose);
+        return rowMajorMatrix;
+      },
+      "joint_angles"_a,
+      "tcp_pose"_a = Matrix4x4::Identity(),
+      "Calculates the forward kinematics of the robot, providing the TCP pose in the robot's base frame for a given "
+      "joint configuration"
+      // TODO(tlpss): figure out how to use multi-line docstrings
 
-void define_forward_kinematics_with_tcp(
-    nb::module_ &robot_module,
-    std::function<Matrix4x4(double, double, double, double, double, double, Matrix4x4)> fk_with_tcp_function) {
-  robot_module.def("forward_kinematics_with_tcp",
-                   [=](double theta1,
-                       double theta2,
-                       double theta3,
-                       double theta4,
-                       double theta5,
-                       double theta6,
-                       Matrix4x4 tcp_transform) {
-                     // Call the FK function
-                     Matrix4x4 rowMajorMatrix = fk_with_tcp_function(
-                         theta1, theta2, theta3, theta4, theta5, theta6, tcp_transform);
+      //  "Calculates the forward kinematics of the robot, providing the TCP pose in the robot's base frame for a given
+      //  joint configuration Also takes in the offset (pose) of the TCP w.r.t. the flange frame, as the FK function
+      //  only knows the kinematics of the robot, not the tool.
 
-                     return rowMajorMatrix;
-                   });
+      //   :param joint_angles: A 6-element vector containing the joint angles in radians.
+      //   :param tcp_pose: A 4x4 matrix representing the pose of the TCP in the robot tool frame. Defaults to
+      //   identity, in which case the TCP is assumed to be at the flange.
+
+      //   :return: A 4x4 matrix representing the pose of the TCP in the robot base frame.
+      //  "
+  );
 }
 
 void define_inverse_kinematics(nb::module_ &robot_module,
@@ -96,7 +93,6 @@ void define_inverse_kinematics_closest_with_tcp(
 NB_MODULE(ur_analytic_ik_ext, m) {
   nb::module_ m_ur3e = m.def_submodule("ur3e", "UR3e module");
   define_forward_kinematics(m_ur3e, ur3e::forward_kinematics);
-  define_forward_kinematics_with_tcp(m_ur3e, ur3e::forward_kinematics_with_tcp);
   define_inverse_kinematics(m_ur3e, ur3e::inverse_kinematics);
   define_inverse_kinematics_closest(m_ur3e, ur3e::inverse_kinematics_closest);
   define_inverse_kinematics_with_tcp(m_ur3e, ur3e::inverse_kinematics_with_tcp);
@@ -104,7 +100,6 @@ NB_MODULE(ur_analytic_ik_ext, m) {
 
   nb::module_ m_ur5e = m.def_submodule("ur5e", "UR5e module");
   define_forward_kinematics(m_ur5e, ur5e::forward_kinematics);
-  define_forward_kinematics_with_tcp(m_ur5e, ur5e::forward_kinematics_with_tcp);
   define_inverse_kinematics(m_ur5e, ur5e::inverse_kinematics);
   define_inverse_kinematics_closest(m_ur5e, ur5e::inverse_kinematics_closest);
   define_inverse_kinematics_with_tcp(m_ur5e, ur5e::inverse_kinematics_with_tcp);
@@ -112,7 +107,6 @@ NB_MODULE(ur_analytic_ik_ext, m) {
 
   nb::module_ m_ur10e = m.def_submodule("ur10e", "UR10e module");
   define_forward_kinematics(m_ur10e, ur10e::forward_kinematics);
-  define_forward_kinematics_with_tcp(m_ur10e, ur10e::forward_kinematics_with_tcp);
   define_inverse_kinematics(m_ur10e, ur10e::inverse_kinematics);
   define_inverse_kinematics_closest(m_ur10e, ur10e::inverse_kinematics_closest);
   define_inverse_kinematics_with_tcp(m_ur10e, ur10e::inverse_kinematics_with_tcp);

--- a/tests/test_forward_kinematics.py
+++ b/tests/test_forward_kinematics.py
@@ -1,0 +1,27 @@
+def test_arguments_w_default_values():
+    """
+    test if the FK function works with default arguments
+    """
+    import numpy as np
+    from ur_analytic_ik import ur5e
+    joint_config = np.array([0,0,0,0,0,0])
+    fk_pose = ur5e.forward_kinematics(joint_config)
+
+    assert isinstance(fk_pose, np.ndarray), f"Expected a numpy array, got {type(fk_pose)}"
+    assert fk_pose.shape == (4,4), f"Expected a 4x4 matrix, got {fk_pose.shape}"
+
+def test_arguments_w_tcp_pose():
+    """
+    test if the FK function works with a custom TCP pose
+    """
+    import numpy as np
+    from ur_analytic_ik import ur5e
+    joint_config = np.array([0,0,0,0,0,0])
+    tcp_pose = np.array([[1,0,0,0.1],
+                          [0,1,0,0.1],
+                          [0,0,1,0.1],
+                          [0,0,0,1]])
+    fk_pose = ur5e.forward_kinematics(joint_config, tcp_pose)
+
+    assert isinstance(fk_pose, np.ndarray), f"Expected a numpy array, got {type(fk_pose)}"
+    assert fk_pose.shape == (4,4), f"Expected a 4x4 matrix, got {fk_pose.shape}"

--- a/tests/test_inverse_kinematics.py
+++ b/tests/test_inverse_kinematics.py
@@ -38,26 +38,26 @@ def seed():
 def test_consistency():
     for _ in range(10000):
         random_joints = np.random.uniform(-2 * np.pi, 2 * np.pi, 6)
-        eef_pose = ur5e.forward_kinematics(*random_joints)
+        eef_pose = ur5e.forward_kinematics(random_joints)
         joint_solutions = ur5e.inverse_kinematics(np.array(eef_pose))
 
         if len(joint_solutions) <= 1:
             continue  # A single solution is always consistent with itself
 
-        eef_pose0 = ur5e.forward_kinematics(*joint_solutions[0].squeeze())
+        eef_pose0 = ur5e.forward_kinematics(joint_solutions[0].squeeze())
         for joints in joint_solutions[1:]:
-            eefpose = ur5e.forward_kinematics(*joints.squeeze())
+            eefpose = ur5e.forward_kinematics(joints.squeeze())
             assert np.allclose(eef_pose0, eefpose)
 
 
 def test_correctness():
     for _ in range(10000):
         random_joints = np.random.uniform(-2 * np.pi, 2 * np.pi, 6)
-        original_eef_pose = np.array(ur5e.forward_kinematics(*random_joints))
+        original_eef_pose = np.array(ur5e.forward_kinematics(random_joints))
         joint_solutions = ur5e.inverse_kinematics(original_eef_pose)
 
         for joints in joint_solutions:
-            eef_pose = np.array(ur5e.forward_kinematics(*joints.squeeze()))
+            eef_pose = np.array(ur5e.forward_kinematics(joints.squeeze()))
             assert np.allclose(eef_pose, original_eef_pose)
 
 def test_correctness_edges_cases():
@@ -66,18 +66,18 @@ def test_correctness_edges_cases():
     ]
 
     for joints in edge_case_joints:
-        original_eef_pose = np.array(ur5e.forward_kinematics(*joints))
+        original_eef_pose = np.array(ur5e.forward_kinematics(joints))
         joint_solutions = ur5e.inverse_kinematics(original_eef_pose)
 
         for joints in joint_solutions:
-            eef_pose = np.array(ur5e.forward_kinematics(*joints.squeeze()))
+            eef_pose = np.array(ur5e.forward_kinematics(joints.squeeze()))
             assert np.allclose(eef_pose, original_eef_pose)
 
 
 def test_inclusion():
     for _ in range(10000):
         random_joints = np.random.uniform(-np.pi, np.pi, 6)  # Smaller range for equality check to work
-        eef_pose = ur5e.forward_kinematics(*random_joints)
+        eef_pose = ur5e.forward_kinematics(random_joints)
         joint_solutions = ur5e.inverse_kinematics(np.array(eef_pose))
 
         # random_joints should be one of the solutions
@@ -103,7 +103,7 @@ def test_strictness():
 def test_range():
     for _ in range(10000):
         random_joints = np.random.uniform(2 * np.pi, 2 * np.pi, 6)
-        eef_pose = ur5e.forward_kinematics(*random_joints)
+        eef_pose = ur5e.forward_kinematics(random_joints)
         joint_solutions = ur5e.inverse_kinematics(np.array(eef_pose))
 
         for joints in joint_solutions:
@@ -130,7 +130,7 @@ def test_axis_aliged_eef_pose():
     assert len(joint_solutions) == 8
 
     for joints in joint_solutions:
-        eef_pose = np.array(ur5e.forward_kinematics(*joints.squeeze()))
+        eef_pose = np.array(ur5e.forward_kinematics(joints.squeeze()))
         assert np.allclose(easily_reachable_pose, eef_pose)
 
 
@@ -138,7 +138,7 @@ def test_closest():
     for _ in range(10000):
         # just some random pose we want to reach by specifying it in joint space and then going to task space
         __q_target = np.random.uniform(-2 * np.pi, 2 * np.pi, 6)
-        X_target = np.array(ur5e.forward_kinematics(*__q_target))
+        X_target = np.array(ur5e.forward_kinematics(__q_target))
 
         # here the real test starts
         q_targets = ur5e.inverse_kinematics(X_target)
@@ -185,7 +185,7 @@ def test_with_tcp():
 
     zeros = np.zeros(6)
 
-    tcp_pose = ur5e.forward_kinematics_with_tcp(*zeros, tcp_transform)
+    tcp_pose = ur5e.forward_kinematics(zeros, tcp_transform)
     joint_solutions = ur5e.inverse_kinematics_with_tcp(np.array(tcp_pose), tcp_transform)
 
     # Check whether all joints are close to zero or two pi.

--- a/tests/test_non_contiguous_numpy.py
+++ b/tests/test_non_contiguous_numpy.py
@@ -19,5 +19,5 @@ def test_non_contiguous(robot):
     assert len(joint_solutions) == 8, f"Expected 8 solutions, got {len(joint_solutions)}"
 
     for joints in joint_solutions:
-        eef_pose = np.array(robot.forward_kinematics(*joints.squeeze()))
+        eef_pose = np.array(robot.forward_kinematics(joints.squeeze()))
         assert np.allclose(eef_pose, pose), f"Expected {pose}, got {eef_pose} for one of the joint configurations"

--- a/tests/test_solutions_match_real_robot.py
+++ b/tests/test_solutions_match_real_robot.py
@@ -17,7 +17,7 @@ def read_poses(file):
         # strip the brackets
         joint_config[0] = joint_config[0][1:]
         joint_config[-1] = joint_config[-1][:-1]
-        joint_config = [float(j) for j in joint_config]
+        joint_config = np.array([float(j) for j in joint_config])
         
         pose = pose.split(",")
         # remove all brackets
@@ -39,6 +39,6 @@ def test_solutions_match_real_ur5e():
         assert np.isclose(joint_solution, joint_config,atol=1e-2).all()
 
 
-        fk_pose = ur5e.forward_kinematics(*joint_config)
+        fk_pose = ur5e.forward_kinematics(joint_config)
         assert np.linalg.norm(fk_pose[:3,3] - pose[:3,3]) < 3e-3 # 3mm tolerance
         


### PR DESCRIPTION
New API for FK and IK that 

1. uses optional arguments to pass TCP pose in flange frame
2. uses numpy arrays <-> Eigen Matrix<1,6> for joint configuration inputs, instead of 6 separate floats.

e.g. 

```

joints = np.zeros(6)
tcp_in_flange = np.identity(4)
pose = ur3e.forward_kinematics(joints, tcp_in_flange)
pose2 = ur3e.forward_kinematics(joints)
```



TODOs:
- [X] FK
- [ ] IK 